### PR TITLE
feat: pass just recent domains to scanDomains instead of whole blocklist object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,9 +65,10 @@ export async function fetchDomainBlocklistBloomFilter(
 // Scan if url's domain is blocked by the bloom filter or is contained in the "recent domains" list.
 //
 // This function does not implement any priority logic and considers any domain in the blocklist blocked.
+// `recent` has to be passed from stored blocklist object.
 export function scanDomain(
-  blocklist: DomainBlocklist,
   bloomFilter: BloomFilter,
+  recent: string[],
   url: string
 ): Action {
   const domain = new URL(url).hostname.toLowerCase();
@@ -77,7 +78,7 @@ export function scanDomain(
   // Blowfish API is responsible for not including public suffix domains to the bloom filter.
   for (let i = 0; i < domainParts.length - 1; i++) {
     const domainToLookup = domainParts.slice(i).join(".");
-    if (blocklist.recent.includes(domainToLookup)) {
+    if (recent.includes(domainToLookup)) {
       return Action.BLOCK;
     }
     if (lookup(bloomFilter, domainToLookup)) {


### PR DESCRIPTION
I've made a blunder while designing the API — `scanDomains` only needs `recent` from the blocklist object, but I've made it accept whole `DomainBlocklist` as an argument. 

Don from Phantom asked for an option to just send the `recent`:
>Is there any reason to pass in the bloomFilter: {url: "", hash: "" } as part of the scanDomain method? Would it be possible to just pass in the recent, bloomFilter  and domain?

Luckily, since we don't have any more clients yet, we can easily switch this API.

Fixes NIP-1078.