### PR TITLE
feat: move to base64 for bitvector encoding (NIP-1111)

### DIFF
--- a/src/bloomFilter.ts
+++ b/src/bloomFilter.ts
@@ -1,6 +1,17 @@
 import sha1 from "sha1";
 import type { BloomFilter } from "./types";
 
+// This is an implementation of a bloom filter lookup algorithm.
+//
+// Algorithm should exactly match the one used to generate the bloom filter.
+// In order to simplify the algorithm, we're using a universal hash function
+// and generate hashes from scratch for each key.
+//
+// Bloom filter's bitVector is expected to have base64-encoded bytes,
+// which represent bits in bloom filter's bit vector.
+// First bit in vector is highest order bit of the first encoded byte.
+// See encoding implementation in
+// https://github.com/contain-rs/bit-vec/blob/d15090df70f6499da2c9770942c8d39750cb1a21/src/lib.rs#L1120.
 export function lookup(bloomFilter: BloomFilter, key: string): boolean {
   // `k` means number of hash functions used for each lookup/insert.
   for (let i = 0; i < bloomFilter.k; i++) {

--- a/src/bloomFilter.ts
+++ b/src/bloomFilter.ts
@@ -30,7 +30,7 @@ export function lookup(bloomFilter: BloomFilter, key: string): boolean {
     );
     // Within this sequence, we need extract just one bit.
     const bitInSequence = index % 24;
-    // This calculates specific byte & bit where are looking for in the 24-bit sequence.
+    // This calculates specific byte & bit we are looking for in the 24-bit sequence.
     const byte = Math.floor(bitInSequence / 8);
     const bit = bitInSequence % 8;
     // Lookup bit in the bit vector using a bit mask.

--- a/src/bloomFilter.ts
+++ b/src/bloomFilter.ts
@@ -1,16 +1,6 @@
 import sha1 from "sha1";
 import type { BloomFilter } from "./types";
 
-// This is an implementation of a bloom filter lookup algorithm.
-//
-// Algorithm should exactly match the one used to generate the bloom filter.
-// In order to simplify the algorithm, we're using a universal hash function
-// and generate hashes from scratch for each key.
-//
-// Bloom filter's bitVector is expected to have 8 bits in each element (u8[]).
-// First bit in vector is highest order bit in the first element.
-// See encoding implementation in
-// https://github.com/contain-rs/bit-vec/blob/d15090df70f6499da2c9770942c8d39750cb1a21/src/lib.rs#L1120.
 export function lookup(bloomFilter: BloomFilter, key: string): boolean {
   // `k` means number of hash functions used for each lookup/insert.
   for (let i = 0; i < bloomFilter.k; i++) {
@@ -20,12 +10,22 @@ export function lookup(bloomFilter: BloomFilter, key: string): boolean {
     const buffer = Buffer.from(hash).subarray(0, 4);
     // Determine bit vector position for bit that we're seeking. Each integer in bloomFilter.bitVector has 8 bits.
     const index = buffer.readUInt32BE(0) % bloomFilter.bits;
-    const byte = Math.floor(index / 8);
-    const bit = index % 8;
+    // Base64 encodes 24 bits (3 bytes) in 4 characters (4 bytes).
+    // So, we need extract a 24-bit base64-encoded sequence, which is basically a 4 character string slice.
+    const sequenceIndex = Math.floor(index / 24);
+    const sequence = Buffer.from(
+      bloomFilter.bitVector.slice(sequenceIndex * 4, sequenceIndex * 4 + 4),
+      "base64"
+    );
+    // Within this sequence, we need extract just one bit.
+    const bitInSequence = index % 24;
+    // This calculates specific byte & bit where are looking for in the 24-bit sequence.
+    const byte = Math.floor(bitInSequence / 8);
+    const bit = bitInSequence % 8;
     // Lookup bit in the bit vector using a bit mask.
     // We invert `bit` position, because `bit` is counted from highest order bit.
     // 1 << 7 selects highest order bit, 1 << 0 selects lowest order bit.
-    if ((bloomFilter.bitVector[byte] & (1 << (7 - bit))) === 0) {
+    if ((sequence[byte] & (1 << (7 - bit))) === 0) {
       // If lookup isn't successful, the item is definitely not in the bloom filter.
       return false;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type DomainBlocklist = {
 };
 
 export type BloomFilter = {
-  bitVector: number[];
+  bitVector: string;
   k: number;
   hash: string;
   bits: number;

--- a/test/bloomFilter.test.ts
+++ b/test/bloomFilter.test.ts
@@ -5,10 +5,7 @@ describe("lookup", () => {
   it("should return true for a key that exists in the bloom filter", () => {
     const bloomFilter: BloomFilter = {
       hash: "39570c5c52ebe3f8b8cee74ffc29107189fc216f37e52d9eb7b13c613dad7e05",
-      bitVector: [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-      ],
+      bitVector: "AAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAA=",
       k: 1,
       bits: 256,
       salt: "abc",
@@ -20,10 +17,7 @@ describe("lookup", () => {
   it("should return false for a key that does not exist in the bloom filter", () => {
     const bloomFilter: BloomFilter = {
       hash: "39570c5c52ebe3f8b8cee74ffc29107189fc216f37e52d9eb7b13c613dad7e05",
-      bitVector: [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-      ],
+      bitVector: "AAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAA=",
       k: 1,
       bits: 256,
       salt: "abc",
@@ -35,10 +29,7 @@ describe("lookup", () => {
   it("should return true for a key that exists in the bloom filter with k=2", () => {
     const bloomFilter: BloomFilter = {
       hash: "39570c5c52ebe3f8b8cee74ffc29107189fc216f37e52d9eb7b13c613dad7e05",
-      bitVector: [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 8, 0,
-      ],
+      bitVector: "AAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAACAA=",
       k: 2,
       bits: 256,
       salt: "abc",
@@ -50,10 +41,7 @@ describe("lookup", () => {
   it("should return false for a key does not exist in the bloom filter with k=2", () => {
     const bloomFilter: BloomFilter = {
       hash: "39570c5c52ebe3f8b8cee74ffc29107189fc216f37e52d9eb7b13c613dad7e05",
-      bitVector: [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 8, 0,
-      ],
+      bitVector: "AAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAACAA=",
       k: 2,
       bits: 256,
       salt: "abc",
@@ -66,10 +54,7 @@ describe("lookup", () => {
   it("should return true for a key that exists in the bloom filter with k=2 and n=257", () => {
     const bloomFilter: BloomFilter = {
       hash: "39570c5c52ebe3f8b8cee74ffc29107189fc216f37e52d9eb7b13c613dad7e05",
-      bitVector: [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 1, 16, 0, 0, 0, 0, 0,
-      ],
+      bitVector: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAAAAA",
       k: 2,
       bits: 257,
       salt: "abc",
@@ -81,10 +66,7 @@ describe("lookup", () => {
   it("should return false when salt is provided incorrectly", () => {
     const bloomFilter: BloomFilter = {
       hash: "39570c5c52ebe3f8b8cee74ffc29107189fc216f37e52d9eb7b13c613dad7e05",
-      bitVector: [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 1, 16, 0, 0, 0, 0, 0,
-      ],
+      bitVector: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAAAAA",
       k: 2,
       bits: 257,
       salt: "abcd",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../src";
 
 const EMPTY_BLOOM_FILTER: BloomFilter = {
-  bitVector: [0],
+  bitVector: "AA",
   k: 1,
   hash: "",
   bits: 8,
@@ -136,10 +136,7 @@ describe("scanDomain", () => {
         // This bloom filter contains the domain "google.com"
         {
           hash: "39570c5c52ebe3f8b8cee74ffc29107189fc216f37e52d9eb7b13c613dad7e05",
-          bitVector: [
-            0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0,
-          ],
+          bitVector: "AAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
           k: 1,
           bits: 256,
           salt: "abc",
@@ -156,10 +153,7 @@ describe("scanDomain", () => {
         // This bloom filter contains the domain "google.com"
         {
           hash: "39570c5c52ebe3f8b8cee74ffc29107189fc216f37e52d9eb7b13c613dad7e05",
-          bitVector: [
-            0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0,
-          ],
+          bitVector: "AAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
           k: 1,
           bits: 256,
           salt: "abc",


### PR DESCRIPTION
After looking into encoded bloom filter sizes, I've decided that it would be better long-term to move to base64 for encoding, instead of encoding bits as byte-numbers. While it looks more obscure when inspecting JSON (that's why I initially rejected the idea of doing this), it delivers significant improvements on usage of local storage.

Bloom filter JSON size using `[]number`: 1.8MB (672KB gzipped).
Using base64 `string`: 719 KB (531KB gzipped).

Cloudfront automatically gzips all data, so this won't bring proper network improvements, but it would allow integrators to use much less data when storing the object in local storage (5MB limit per extension).  

Tests are failed expectedly, since we haven't updated S3 bloom filter yet. All non-integration tests work properly.