### PR TITLE
feat: allow integrators to track errors thrown 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,43 +21,47 @@ export const DEFAULT_BLOCKLIST_URL =
 export async function fetchDomainBlocklist(
   apiConfig: ApiConfig,
   priorityBlockLists: string[] = [],
-  priorityAllowLists: string[] = []
+  priorityAllowLists: string[] = [],
+  reportError: (error: unknown) => void = () => {}
 ): Promise<DomainBlocklist | null> {
   const apiKeyConfig = apiConfig.apiKey
     ? { headers: { "x-api-key": apiConfig.apiKey } }
     : {};
-  // We wrap errors with a null so any downtime won't break user's browsing flow.
-  const response = await fetch(apiConfig.domainBlocklistUrl, {
-    method: "POST",
-    body: JSON.stringify({
-      priorityBlockLists,
-      priorityAllowLists,
-    }),
-    ...apiKeyConfig,
-  });
-  if (!response.ok) {
-    return null;
-  }
-  // Catch JSON decoding errors
   try {
+    // We wrap errors with a null so any downtime won't break user's browsing flow.
+    const response = await fetch(apiConfig.domainBlocklistUrl, {
+      method: "POST",
+      body: JSON.stringify({
+        priorityBlockLists,
+        priorityAllowLists,
+      }),
+      ...apiKeyConfig,
+    });
+    if (!response.ok) {
+      return null;
+    }
+    // Catch JSON decoding errors too.
     return (await response.json()) as DomainBlocklist;
-  } catch {
+  } catch (error: unknown) {
+    reportError(error);
     return null;
   }
 }
 
 // Fetch bloom filter JSON object from CDN url.
 export async function fetchDomainBlocklistBloomFilter(
-  url: string
+  url: string,
+  reportError: (error: unknown) => void = () => {}
 ): Promise<BloomFilter | null> {
-  const response = await fetch(url);
-  if (!response.ok) {
-    return null;
-  }
-  // Catch JSON decoding errors
   try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      return null;
+    }
+    // Catch JSON decoding errors too.
     return (await response.json()) as BloomFilter;
-  } catch {
+  } catch (error: unknown) {
+    reportError(error);
     return null;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,9 @@ export async function fetchDomainBlocklist(
       ...apiKeyConfig,
     });
     if (!response.ok) {
+      if (reportError) {
+        reportError(await response.text());
+      }
       return null;
     }
     // Catch JSON decoding errors too.
@@ -60,6 +63,9 @@ export async function fetchDomainBlocklistBloomFilter(
   try {
     const response = await fetch(url);
     if (!response.ok) {
+      if (reportError) {
+        reportError(await response.text());
+      }
       return null;
     }
     // Catch JSON decoding errors too.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ export type { ApiConfig, Action, BloomFilter, DomainBlocklist };
 export const DEFAULT_BLOCKLIST_URL =
   "https://api.blowfish.xyz/v0/domains/blocklist";
 
+export type ErrorCallback = (error: unknown) => void;
+
 // Fetch blocklist JSON object from Blowfish API with link to bloom filter and recent domains.
 //
 // Blocklist should be fetched/updated in two steps.
@@ -22,7 +24,7 @@ export async function fetchDomainBlocklist(
   apiConfig: ApiConfig,
   priorityBlockLists: string[] = [],
   priorityAllowLists: string[] = [],
-  reportError: (error: unknown) => void = () => {}
+  reportError: ErrorCallback | undefined = undefined
 ): Promise<DomainBlocklist | null> {
   const apiKeyConfig = apiConfig.apiKey
     ? { headers: { "x-api-key": apiConfig.apiKey } }
@@ -43,7 +45,9 @@ export async function fetchDomainBlocklist(
     // Catch JSON decoding errors too.
     return (await response.json()) as DomainBlocklist;
   } catch (error: unknown) {
-    reportError(error);
+    if (reportError) {
+      reportError(error);
+    }
     return null;
   }
 }
@@ -51,7 +55,7 @@ export async function fetchDomainBlocklist(
 // Fetch bloom filter JSON object from CDN url.
 export async function fetchDomainBlocklistBloomFilter(
   url: string,
-  reportError: (error: unknown) => void = () => {}
+  reportError: ErrorCallback | undefined = undefined
 ): Promise<BloomFilter | null> {
   try {
     const response = await fetch(url);
@@ -61,7 +65,9 @@ export async function fetchDomainBlocklistBloomFilter(
     // Catch JSON decoding errors too.
     return (await response.json()) as BloomFilter;
   } catch (error: unknown) {
-    reportError(error);
+    if (reportError) {
+      reportError(error);
+    }
     return null;
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -33,6 +33,7 @@ describe("fetchDomainBlocklist", () => {
   });
 
   it("tracks thrown errors using a passed function", async () => {
+    // eslint-disable-next-line prefer-const
     let errors: unknown[] = [];
     const reportError = (error: unknown) => {
       errors.push(error);
@@ -42,7 +43,7 @@ describe("fetchDomainBlocklist", () => {
     };
     await fetchDomainBlocklist(apiConfig, undefined, undefined, reportError);
     expect(errors.length).toBe(1);
-    expect((errors[0] as any).message).toBe(
+    expect((errors[0] as Error).message).toBe(
       "request to http://2ceamjtzctdx8ht2.com/ failed, reason: getaddrinfo ENOTFOUND 2ceamjtzctdx8ht2.com"
     );
   });
@@ -69,6 +70,7 @@ describe("fetchDomainBlocklistBloomFilter", () => {
   });
 
   it("tracks thrown errors using a passed function", async () => {
+    // eslint-disable-next-line prefer-const
     let errors: unknown[] = [];
     const reportError = (error: unknown) => {
       errors.push(error);
@@ -79,7 +81,7 @@ describe("fetchDomainBlocklistBloomFilter", () => {
     );
 
     expect(errors.length).toBe(1);
-    expect((errors[0] as any).message).toBe(
+    expect((errors[0] as Error).message).toBe(
       "request to http://2ceamjtzctdx8ht2.com/ failed, reason: getaddrinfo ENOTFOUND 2ceamjtzctdx8ht2.com"
     );
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -59,9 +59,7 @@ describe("fetchDomainBlocklist", () => {
     };
     await fetchDomainBlocklist(apiConfig, undefined, undefined, reportError);
     expect(errors.length).toBe(1);
-    expect(errors[0] as string).toContain(
-      "Error 404 (Not Found)"
-    );
+    expect(errors[0] as string).toContain("Error 404 (Not Found)");
   });
 });
 
@@ -113,9 +111,7 @@ describe("fetchDomainBlocklistBloomFilter", () => {
       reportError
     );
     expect(errors.length).toBe(1);
-    expect(errors[0] as string).toContain(
-      "Error 404 (Not Found)"
-    );
+    expect(errors[0] as string).toContain("Error 404 (Not Found)");
   });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -31,6 +31,21 @@ describe("fetchDomainBlocklist", () => {
     expect(blocklist!.bloomFilter).toHaveProperty("hash");
     expect(blocklist!.bloomFilter.hash).not.toBe("");
   });
+
+  it("tracks thrown errors using a passed function", async () => {
+    let errors: unknown[] = [];
+    const reportError = (error: unknown) => {
+      errors.push(error);
+    }
+    const apiConfig: ApiConfig = {
+      domainBlocklistUrl: "http://2CeaMJtzCTdx8ht2.com/" // this domain does not exist
+    };
+    await fetchDomainBlocklist(
+      apiConfig, undefined, undefined, reportError
+    );
+    expect(errors.length).toBe(1);
+    expect((errors[0] as any).message).toBe("request to http://2ceamjtzctdx8ht2.com/ failed, reason: getaddrinfo ENOTFOUND 2ceamjtzctdx8ht2.com");
+  });
 });
 
 describe("fetchDomainBlocklistBloomFilter", () => {
@@ -51,6 +66,20 @@ describe("fetchDomainBlocklistBloomFilter", () => {
     expect(bloomFilter).toHaveProperty("hash");
     expect(bloomFilter).toHaveProperty("bits");
     expect(bloomFilter).toHaveProperty("salt");
+  });
+
+  it("tracks thrown errors using a passed function", async () => {
+    let errors: unknown[] = [];
+    const reportError = (error: unknown) => {
+      errors.push(error);
+    }
+    await fetchDomainBlocklistBloomFilter(
+      "http://2CeaMJtzCTdx8ht2.com/", // this domain does not exist
+      reportError
+    );
+
+    expect(errors.length).toBe(1);
+    expect((errors[0] as any).message).toBe("request to http://2ceamjtzctdx8ht2.com/ failed, reason: getaddrinfo ENOTFOUND 2ceamjtzctdx8ht2.com");
   });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -47,6 +47,22 @@ describe("fetchDomainBlocklist", () => {
       "request to http://2ceamjtzctdx8ht2.com/ failed, reason: getaddrinfo ENOTFOUND 2ceamjtzctdx8ht2.com"
     );
   });
+
+  it("tracks !response.ok errors using a passed function", async () => {
+    // eslint-disable-next-line prefer-const
+    let errors: unknown[] = [];
+    const reportError = (error: unknown) => {
+      errors.push(error);
+    };
+    const apiConfig: ApiConfig = {
+      domainBlocklistUrl: "https://google.com/fdjfkdkdkfdkdf/", // this should return 404
+    };
+    await fetchDomainBlocklist(apiConfig, undefined, undefined, reportError);
+    expect(errors.length).toBe(1);
+    expect(errors[0] as string).toContain(
+      "Error 404 (Not Found)"
+    );
+  });
 });
 
 describe("fetchDomainBlocklistBloomFilter", () => {
@@ -83,6 +99,22 @@ describe("fetchDomainBlocklistBloomFilter", () => {
     expect(errors.length).toBe(1);
     expect((errors[0] as Error).message).toBe(
       "request to http://2ceamjtzctdx8ht2.com/ failed, reason: getaddrinfo ENOTFOUND 2ceamjtzctdx8ht2.com"
+    );
+  });
+
+  it("tracks !response.ok errors using a passed function", async () => {
+    // eslint-disable-next-line prefer-const
+    let errors: unknown[] = [];
+    const reportError = (error: unknown) => {
+      errors.push(error);
+    };
+    await fetchDomainBlocklistBloomFilter(
+      "https://google.com/fdjfkdkdkfdkdf/", // this should return 404
+      reportError
+    );
+    expect(errors.length).toBe(1);
+    expect(errors[0] as string).toContain(
+      "Error 404 (Not Found)"
     );
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -36,15 +36,15 @@ describe("fetchDomainBlocklist", () => {
     let errors: unknown[] = [];
     const reportError = (error: unknown) => {
       errors.push(error);
-    }
-    const apiConfig: ApiConfig = {
-      domainBlocklistUrl: "http://2CeaMJtzCTdx8ht2.com/" // this domain does not exist
     };
-    await fetchDomainBlocklist(
-      apiConfig, undefined, undefined, reportError
-    );
+    const apiConfig: ApiConfig = {
+      domainBlocklistUrl: "http://2CeaMJtzCTdx8ht2.com/", // this domain does not exist
+    };
+    await fetchDomainBlocklist(apiConfig, undefined, undefined, reportError);
     expect(errors.length).toBe(1);
-    expect((errors[0] as any).message).toBe("request to http://2ceamjtzctdx8ht2.com/ failed, reason: getaddrinfo ENOTFOUND 2ceamjtzctdx8ht2.com");
+    expect((errors[0] as any).message).toBe(
+      "request to http://2ceamjtzctdx8ht2.com/ failed, reason: getaddrinfo ENOTFOUND 2ceamjtzctdx8ht2.com"
+    );
   });
 });
 
@@ -72,14 +72,16 @@ describe("fetchDomainBlocklistBloomFilter", () => {
     let errors: unknown[] = [];
     const reportError = (error: unknown) => {
       errors.push(error);
-    }
+    };
     await fetchDomainBlocklistBloomFilter(
       "http://2CeaMJtzCTdx8ht2.com/", // this domain does not exist
       reportError
     );
 
     expect(errors.length).toBe(1);
-    expect((errors[0] as any).message).toBe("request to http://2ceamjtzctdx8ht2.com/ failed, reason: getaddrinfo ENOTFOUND 2ceamjtzctdx8ht2.com");
+    expect((errors[0] as any).message).toBe(
+      "request to http://2ceamjtzctdx8ht2.com/ failed, reason: getaddrinfo ENOTFOUND 2ceamjtzctdx8ht2.com"
+    );
   });
 });
 


### PR DESCRIPTION
Normally, we swallow all happened errors. This change adds a feature to get errors reported via a callback. The method would still produce `null`.

Additionally, I noticed that I didn't properly handle all of error cases 🙈 So there is a tiny fix related to that as well.