### PR TITLE
feat: make package compatible with react native

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/jest": "^29.2.5",
     "@types/node": "^18.11.18",
     "@types/sha1": "^1.1.3",
+    "@types/whatwg-url": "^11.0.0",
     "@typescript-eslint/eslint-plugin": "^5.48.1",
     "@typescript-eslint/parser": "^5.48.1",
     "eslint": "^8.32.0",
@@ -50,6 +51,7 @@
   },
   "dependencies": {
     "cross-fetch": "^3.1.5",
-    "sha1": "^1.1.1"
+    "sha1": "^1.1.1",
+    "whatwg-url": "^12.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ specifiers:
   '@types/jest': ^29.2.5
   '@types/node': ^18.11.18
   '@types/sha1': ^1.1.3
+  '@types/whatwg-url': ^11.0.0
   '@typescript-eslint/eslint-plugin': ^5.48.1
   '@typescript-eslint/parser': ^5.48.1
   cross-fetch: ^3.1.5
@@ -14,15 +15,18 @@ specifiers:
   ts-jest: ^29.0.5
   tsup: ^6.5.0
   typescript: ^4.9.4
+  whatwg-url: ^12.0.0
 
 dependencies:
   cross-fetch: 3.1.5
   sha1: 1.1.1
+  whatwg-url: 12.0.0
 
 devDependencies:
   '@types/jest': 29.2.5
   '@types/node': 18.11.18
   '@types/sha1': 1.1.3
+  '@types/whatwg-url': 11.0.0
   '@typescript-eslint/eslint-plugin': 5.48.1_oomjohfipuyaxs2zyomcx4f5by
   '@typescript-eslint/parser': 5.48.1_7uibuqfxkfaozanbtbziikiqje
   eslint: 8.32.0
@@ -815,6 +819,16 @@ packages:
 
   /@types/stack-utils/2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+    dev: true
+
+  /@types/webidl-conversions/7.0.0:
+    resolution: {integrity: sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==}
+    dev: true
+
+  /@types/whatwg-url/11.0.0:
+    resolution: {integrity: sha512-4F6szvZP3FM5HvJAmcInXBfrAhvM4tLIc8MO1nXwabG5TZVOLxVmAXRpICqXYd3lBlomSRGmLCopYV+yTocgpQ==}
+    dependencies:
+      '@types/webidl-conversions': 7.0.0
     dev: true
 
   /@types/yargs-parser/21.0.0:
@@ -2917,7 +2931,6 @@ packages:
   /punycode/2.2.0:
     resolution: {integrity: sha512-LN6QV1IJ9ZhxWTNdktaPClrNfp8xdSAYS0Zk2ddX7XsXZAxckMHPCBcHRo0cTcEIgYPRiGEkmji3Idkh2yFtYw==}
     engines: {node: '>=6'}
-    dev: true
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -3206,6 +3219,13 @@ packages:
       punycode: 2.2.0
     dev: true
 
+  /tr46/3.0.0:
+    resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
+    engines: {node: '>=12'}
+    dependencies:
+      punycode: 2.2.0
+    dev: false
+
   /tree-kill/1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -3365,6 +3385,19 @@ packages:
   /webidl-conversions/4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
     dev: true
+
+  /webidl-conversions/7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /whatwg-url/12.0.0:
+    resolution: {integrity: sha512-N2SCrbcSPw0gDyNqE+y5qH1gqiOe+HagWfgRJy2SmDO3C23mISmJhQ3zvZljBv2DWfBdLXypAtecWYZ+mg1krQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      tr46: 3.0.0
+      webidl-conversions: 7.0.0
+    dev: false
 
   /whatwg-url/5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import fetch from "cross-fetch";
+import { URL } from "whatwg-url";
 import { ApiConfig, Action, BloomFilter, DomainBlocklist } from "./types";
 import { lookup } from "./bloomFilter";
 


### PR DESCRIPTION
React Native doesn't support most of the `URL` methods, including ability to get a hostname: https://github.com/facebook/react-native/blob/7f2dd1d49cc3c0bf5e24fdb37f6457151c1f06c4/Libraries/Blob/URL.js#L177

This PR switches usages to an NPM implementation of `URL`. I've also considered using a [react-native-url-polyfill](https://www.npmjs.com/package/react-native-url-polyfill), but seems less elegant and still uses a new dependency.