### PR TITLE
feat: make default priorityBlockLists and priorityAllowLists null by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,8 @@ export type ErrorCallback = (error: unknown) => void;
 // recent domains every 5 minutes.
 export async function fetchDomainBlocklist(
   apiConfig: ApiConfig,
-  priorityBlockLists: string[] = [],
-  priorityAllowLists: string[] = [],
+  priorityBlockLists: string[] | null = null,
+  priorityAllowLists: string[] | null = null,
   reportError: ErrorCallback | undefined = undefined
 ): Promise<DomainBlocklist | null> {
   const apiKeyConfig = apiConfig.apiKey


### PR DESCRIPTION
This change makes `priorityBlockLists` and `priorityAllowLists` null by default. Previously, it was empty.

Empty priority (`[]`) means not prioritizing any blocklists. `null` priority means Blowfish sets default values for priorities, which is currently our own blocklists and whitelists. 