### PR TITLE
feat: change `recent` in the blocklist object to recently added and recently removed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,8 @@ export async function fetchDomainBlocklistBloomFilter(
 // `recent` has to be passed from stored blocklist object.
 export function scanDomain(
   bloomFilter: BloomFilter,
-  recent: string[],
+  recentlyAdded: string[],
+  recentlyRemoved: string[],
   url: string
 ): Action {
   const domain = new URL(url).hostname.toLowerCase();
@@ -95,10 +96,13 @@ export function scanDomain(
   // Blowfish API is responsible for not including public suffix domains to the bloom filter.
   for (let i = 0; i < domainParts.length - 1; i++) {
     const domainToLookup = domainParts.slice(i).join(".");
-    if (recent.includes(domainToLookup)) {
+    if (recentlyAdded.includes(domainToLookup)) {
       return Action.BLOCK;
     }
-    if (lookup(bloomFilter, domainToLookup)) {
+    if (
+      lookup(bloomFilter, domainToLookup) &&
+      !recentlyRemoved.includes(domainToLookup)
+    ) {
       return Action.BLOCK;
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,8 @@ export type ApiConfig = {
 
 export type DomainBlocklist = {
   bloomFilter: { url: string; hash: string };
-  recent: string[];
+  recentlyAdded: string[];
+  recentlyRemoved: string[];
 };
 
 export type BloomFilter = {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -25,8 +25,8 @@ describe("fetchDomainBlocklist", () => {
     const blocklist = await fetchDomainBlocklist(apiConfig);
     expect(blocklist).not.toBeNull();
     expect(blocklist).toHaveProperty("bloomFilter");
-    expect(blocklist).toHaveProperty("recentDeleted");
-    expect(blocklist).toHaveProperty("recentAdded");
+    expect(blocklist).toHaveProperty("recentlyAdded");
+    expect(blocklist).toHaveProperty("recentlyRemoved");
     expect(blocklist!.bloomFilter).toHaveProperty("url");
     expect(blocklist!.bloomFilter.url).not.toBe("");
     expect(blocklist!.bloomFilter).toHaveProperty("hash");

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -25,7 +25,8 @@ describe("fetchDomainBlocklist", () => {
     const blocklist = await fetchDomainBlocklist(apiConfig);
     expect(blocklist).not.toBeNull();
     expect(blocklist).toHaveProperty("bloomFilter");
-    expect(blocklist).toHaveProperty("recent");
+    expect(blocklist).toHaveProperty("recentDeleted");
+    expect(blocklist).toHaveProperty("recentAdded");
     expect(blocklist!.bloomFilter).toHaveProperty("url");
     expect(blocklist!.bloomFilter.url).not.toBe("");
     expect(blocklist!.bloomFilter).toHaveProperty("hash");

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -118,22 +118,32 @@ describe("fetchDomainBlocklistBloomFilter", () => {
 describe("scanDomain", () => {
   it("should return a block action when domain is in the recent list", () => {
     expect(
-      scanDomain(EMPTY_BLOOM_FILTER, ["google.com"], "https://google.com")
+      scanDomain(EMPTY_BLOOM_FILTER, ["google.com"], [], "https://google.com")
     ).toBe("BLOCK");
     expect(
-      scanDomain(EMPTY_BLOOM_FILTER, ["google.com"], "https://www.google.com")
+      scanDomain(
+        EMPTY_BLOOM_FILTER,
+        ["google.com"],
+        [],
+        "https://www.google.com"
+      )
     ).toBe("BLOCK");
   });
 
   it("should return a none action when domain is not in the recent list", () => {
-    expect(scanDomain(EMPTY_BLOOM_FILTER, [], "https://www.google.com")).toBe(
-      "NONE"
-    );
+    expect(
+      scanDomain(EMPTY_BLOOM_FILTER, [], [], "https://www.google.com")
+    ).toBe("NONE");
   });
 
   it("should return a block action when lowercase domain is in the recent blocklist", () => {
     expect(
-      scanDomain(EMPTY_BLOOM_FILTER, ["google.com"], "https://wWw.GoogLE.com")
+      scanDomain(
+        EMPTY_BLOOM_FILTER,
+        ["google.com"],
+        [],
+        "https://wWw.GoogLE.com"
+      )
     ).toBe("BLOCK");
   });
 
@@ -142,6 +152,7 @@ describe("scanDomain", () => {
       scanDomain(
         EMPTY_BLOOM_FILTER,
         ["app1.vercel.com"],
+        [],
         "https://app1.vercel.com"
       )
     ).toBe("BLOCK");
@@ -152,11 +163,17 @@ describe("scanDomain", () => {
       scanDomain(
         EMPTY_BLOOM_FILTER,
         ["app1.vercel.com"],
+        [],
         "https://app2.vercel.com"
       )
     ).toBe("NONE");
     expect(
-      scanDomain(EMPTY_BLOOM_FILTER, ["app1.vercel.com"], "https://vercel.com")
+      scanDomain(
+        EMPTY_BLOOM_FILTER,
+        ["app1.vercel.com"],
+        [],
+        "https://vercel.com"
+      )
     ).toBe("NONE");
   });
 
@@ -165,6 +182,7 @@ describe("scanDomain", () => {
       scanDomain(
         EMPTY_BLOOM_FILTER,
         ["blocked.app1.vercel.com"],
+        [],
         "https://blocked.app1.vercel.com"
       )
     ).toBe("BLOCK");
@@ -172,6 +190,7 @@ describe("scanDomain", () => {
       scanDomain(
         EMPTY_BLOOM_FILTER,
         ["blocked.app1.vercel.com"],
+        [],
         "https://unblocked.app1.vercel.com"
       )
     ).toBe("NONE");
@@ -179,6 +198,7 @@ describe("scanDomain", () => {
       scanDomain(
         EMPTY_BLOOM_FILTER,
         ["blocked.app1.vercel.com"],
+        [],
         "https://app1.vercel.com"
       )
     ).toBe("NONE");
@@ -186,6 +206,7 @@ describe("scanDomain", () => {
       scanDomain(
         EMPTY_BLOOM_FILTER,
         ["blocked.app1.vercel.com"],
+        [],
         "https://vercel.com"
       )
     ).toBe("NONE");
@@ -203,9 +224,28 @@ describe("scanDomain", () => {
           salt: "abc",
         },
         [],
+        [],
         "https://google.com"
       )
     ).toBe("BLOCK");
+  });
+
+  it("should return a none action when domain is in the bloom filter and in the recently removed list", () => {
+    expect(
+      scanDomain(
+        // This bloom filter contains the domain "google.com"
+        {
+          hash: "39570c5c52ebe3f8b8cee74ffc29107189fc216f37e52d9eb7b13c613dad7e05",
+          bitVector: "AAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          k: 1,
+          bits: 256,
+          salt: "abc",
+        },
+        [],
+        ["google.com"],
+        "https://google.com"
+      )
+    ).toBe("NONE");
   });
 
   it("should return a none action when domain not in the bloom filter", () => {
@@ -219,6 +259,7 @@ describe("scanDomain", () => {
           bits: 256,
           salt: "abc",
         },
+        [],
         [],
         "https://yahoo.com"
       )
@@ -235,10 +276,20 @@ describe("scanDomain", () => {
       blocklist!.bloomFilter.url
     );
     expect(
-      scanDomain(bloomFilter!, blocklist!.recent, "https://google.com")
+      scanDomain(
+        bloomFilter!,
+        blocklist!.recentlyAdded,
+        blocklist!.recentlyRemoved,
+        "https://google.com"
+      )
     ).toBe("NONE");
     expect(
-      scanDomain(bloomFilter!, blocklist!.recent, "https://-magiceden.io")
+      scanDomain(
+        bloomFilter!,
+        blocklist!.recentlyAdded,
+        blocklist!.recentlyRemoved,
+        "https://-magiceden.io"
+      )
     ).toBe("BLOCK");
   });
 });


### PR DESCRIPTION
Originally, I added `recent` to blocklist object that's returned from API. It was designed to be able to add new domains to the blocklist without updating (and making user re-download) whole blocklist.

However, it only allows to add new domains to blocklist. Deleting a domain from whitelist, a reasonable operation that might have to be executed urgently, would force a re-download.

I changed it to `recentlyAdded` and `recentlyRemoved`.  `recentlyAdded` blocks domains that are not in the bloom filter. `recentlyRemoved` unblocks domain that are in the bloom filter. 

Tests are failing expectedly, since we haven't deployed the new mock API yet.