### PR TITLE
fix: remove whatwg url package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blowfishxyz/blocklist",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Fetch and execute lookups on Blowfish blocklists",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -51,7 +51,6 @@
   },
   "dependencies": {
     "cross-fetch": "^3.1.5",
-    "sha1": "^1.1.1",
-    "whatwg-url": "^12.0.0"
+    "sha1": "^1.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,12 +15,10 @@ specifiers:
   ts-jest: ^29.0.5
   tsup: ^6.5.0
   typescript: ^4.9.4
-  whatwg-url: ^12.0.0
 
 dependencies:
   cross-fetch: 3.1.5
   sha1: 1.1.1
-  whatwg-url: 12.0.0
 
 devDependencies:
   '@types/jest': 29.2.5
@@ -2931,6 +2929,7 @@ packages:
   /punycode/2.2.0:
     resolution: {integrity: sha512-LN6QV1IJ9ZhxWTNdktaPClrNfp8xdSAYS0Zk2ddX7XsXZAxckMHPCBcHRo0cTcEIgYPRiGEkmji3Idkh2yFtYw==}
     engines: {node: '>=6'}
+    dev: true
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -3219,13 +3218,6 @@ packages:
       punycode: 2.2.0
     dev: true
 
-  /tr46/3.0.0:
-    resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
-    engines: {node: '>=12'}
-    dependencies:
-      punycode: 2.2.0
-    dev: false
-
   /tree-kill/1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -3385,19 +3377,6 @@ packages:
   /webidl-conversions/4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
     dev: true
-
-  /webidl-conversions/7.0.0:
-    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /whatwg-url/12.0.0:
-    resolution: {integrity: sha512-N2SCrbcSPw0gDyNqE+y5qH1gqiOe+HagWfgRJy2SmDO3C23mISmJhQ3zvZljBv2DWfBdLXypAtecWYZ+mg1krQ==}
-    engines: {node: '>=14'}
-    dependencies:
-      tr46: 3.0.0
-      webidl-conversions: 7.0.0
-    dev: false
 
   /whatwg-url/5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import fetch from "cross-fetch";
-import { URL } from "whatwg-url";
 import { ApiConfig, Action, BloomFilter, DomainBlocklist } from "./types";
 import { lookup } from "./bloomFilter";
 


### PR DESCRIPTION
It turns out this package creates some hard-to-debug dependency errors in Chrome extensions.

We'll have to recommend our integrators to use `react-native-url-polyfill` in their apps instead.