### PR TITLE
fix: adjust export paths in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@blowfishxyz/blocklist",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Fetch and execute lookups on Blowfish blocklists",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "name": "@blowfishxyz/blocklist",
   "version": "0.0.3",
   "description": "Fetch and execute lookups on Blowfish blocklists",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,12 @@ export async function fetchDomainBlocklist(
   priorityAllowLists: string[] | null = null,
   reportError: ErrorCallback | undefined = undefined
 ): Promise<DomainBlocklist | null> {
+  const headers = {
+    "Content-Type": "application/json",
+  };
   const apiKeyConfig = apiConfig.apiKey
-    ? { headers: { "x-api-key": apiConfig.apiKey } }
-    : {};
+    ? { headers: { "x-api-key": apiConfig.apiKey, ...headers } }
+    : { headers: headers };
   try {
     // We wrap errors with a null so any downtime won't break user's browsing flow.
     const response = await fetch(apiConfig.domainBlocklistUrl, {


### PR DESCRIPTION
After changing to `type: module` `tsup` [builds a bit differently](https://tsup.egoist.dev/#bundle-formats).

Not sure why the tests fail, maybe because of missing api key in CI.

I have also noticed that the response to `https://free.api.blowfish.xyz/v0/domains/blocklist` has only the `recent` field instead of `recentlyAdded` and `recentlyRemoved` (not sure if it matters 😅 )