### PR TITLE
fix: add missing json content-type header

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export async function fetchDomainBlocklist(
   reportError: ErrorCallback | undefined = undefined
 ): Promise<DomainBlocklist | null> {
   const headers = {
-    "Content-Type": "application/json"
+    "Content-Type": "application/json",
   };
   const apiKeyConfig = apiConfig.apiKey
     ? { headers: { "x-api-key": apiConfig.apiKey, ...headers } }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,12 @@ export async function fetchDomainBlocklist(
   priorityAllowLists: string[] | null = null,
   reportError: ErrorCallback | undefined = undefined
 ): Promise<DomainBlocklist | null> {
+  const headers = {
+    "Content-Type": "application/json"
+  };
   const apiKeyConfig = apiConfig.apiKey
-    ? { headers: { "x-api-key": apiConfig.apiKey } }
-    : {};
+    ? { headers: { "x-api-key": apiConfig.apiKey, ...headers } }
+    : { headers: headers };
   try {
     // We wrap errors with a null so any downtime won't break user's browsing flow.
     const response = await fetch(apiConfig.domainBlocklistUrl, {


### PR DESCRIPTION
At some point, our server API started requiring this header and we forgot to add it here.