### PR TITLE
feat: include buffer polyfill for react native apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ It's designed to support React Native, Chrome Extension and Node.js environments
 npm install @blowfishxyz/blocklist
 ```
 
+It's also recommended for React Native apps to install `react-native-url-polyfill`.
+
 ## Usage
 
 In order to execute lookups, you need to fetch a **blocklist object** and **bloom filter**. 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@blowfishxyz/blocklist",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Fetch and execute lookups on Blowfish blocklists",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -51,6 +51,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
+    "buffer": "^6.0.3",
     "cross-fetch": "^3.1.5",
     "sha1": "^1.1.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ specifiers:
   '@types/whatwg-url': ^11.0.0
   '@typescript-eslint/eslint-plugin': ^5.48.1
   '@typescript-eslint/parser': ^5.48.1
+  buffer: ^6.0.3
   cross-fetch: ^3.1.5
   eslint: ^8.32.0
   jest: ^29.3.1
@@ -17,6 +18,7 @@ specifiers:
   typescript: ^4.9.4
 
 dependencies:
+  buffer: 6.0.3
   cross-fetch: 3.1.5
   sha1: 1.1.1
 
@@ -1125,6 +1127,10 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
 
+  /base64-js/1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: false
+
   /binary-extensions/2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
@@ -1171,6 +1177,13 @@ packages:
   /buffer-from/1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: true
+
+  /buffer/6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: false
 
   /bundle-require/3.1.2_esbuild@0.15.18:
     resolution: {integrity: sha512-Of6l6JBAxiyQ5axFxUM6dYeP/W7X2Sozeo/4EYB9sJhL+dqL7TKjg+shwxp6jlu/6ZSERfsYtIpSJ1/x3XkAEA==}
@@ -1985,6 +1998,10 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
     dev: true
+
+  /ieee754/1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    dev: false
 
   /ignore/5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}

--- a/src/bloomFilter.ts
+++ b/src/bloomFilter.ts
@@ -1,4 +1,5 @@
 import sha1 from "sha1";
+import { Buffer } from "buffer";
 import type { BloomFilter } from "./types";
 
 // This is an implementation of a bloom filter lookup algorithm.


### PR DESCRIPTION
From Phantom feedback:

> FYI, we noticed some issues with polyfills in blocklist
Line 23 continues from a buffer, but in a lot of polyfills (like on react-native) this won't work. We created a manual patch for this in the polyfill, but be advised that many devs using react-native will face this issue
![image (1)](https://github.com/blowfishxyz/blocklist/assets/6896447/851389ab-a244-4c87-967b-a9ea9c5d3459)

So, I decided to add a library-wide polyfill for Buffer to support React Native apps.
