### PR TITLE
feat: add cursor to utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@blowfishxyz/blocklist",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Fetch and execute lookups on Blowfish blocklists",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type DomainBlocklist = {
   bloomFilter: { url: string; hash: string };
   recentlyAdded: string[];
   recentlyRemoved: string[];
+  nextCursor: string;
 };
 
 export type BloomFilter = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,6 +34,7 @@ export async function fetchDomainBlocklist(
   },
   priorityBlockLists: string[] | null = null,
   priorityAllowLists: string[] | null = null,
+  cursor: string | null = null,
   reportError: ErrorCallback | undefined = undefined
 ): Promise<DomainBlocklist | null> {
   const headers = {
@@ -49,6 +50,7 @@ export async function fetchDomainBlocklist(
       body: JSON.stringify({
         priorityBlockLists,
         priorityAllowLists,
+        cursor,
       }),
       ...apiKeyConfig,
     });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -32,7 +32,7 @@ describe("fetchDomainBlocklist", () => {
     expect(blocklist!.bloomFilter.hash).not.toBe("");
   });
 
-  it.only("should return a cursor that can be used to re-fetch the blocklist", async () => {
+  it("should return a cursor that can be used to re-fetch the blocklist", async () => {
     const apiConfig = {
       domainBlocklistUrl: DEFAULT_BLOCKLIST_URL,
       apiKey: process.env.BLOWFISH_API_KEY,


### PR DESCRIPTION
I'm adding cursor support only to the utils to unblock integrators that rely on them. Will update `BlowfishLocalBlocklist` later