### PR TITLE
fix: ignore trailing dots at the end of hostname to scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@blowfishxyz/blocklist",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Fetch and execute lookups on Blowfish blocklists",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -103,7 +103,10 @@ export function scanDomain(
   recentlyRemoved: string[],
   url: string
 ): Action {
-  const domain = new URL(url).hostname.toLowerCase();
+  // Take domain hostname without trailing dots at the end, which are often ignored
+  // by browsers.
+  const domain = new URL(url).hostname.toLowerCase().replace(/\.$/, "");
+
   const domainParts = domain.split(".");
   // Lookup all possible subdomains.
   // E.g. for abc.cde.google.com, we'll lookup: abc.cde.google.com, cde.google.com, google.com

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -103,7 +103,7 @@ export function scanDomain(
   recentlyRemoved: string[],
   url: string
 ): Action {
-  // Take domain hostname without trailing dots at the end, which are often ignored
+  // Take domain hostname without trailing dot at the end, which is often ignored
   // by browsers.
   const domain = new URL(url).hostname.toLowerCase().replace(/\.$/, "");
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -165,6 +165,20 @@ describe("scanDomain", () => {
     ).toBe("BLOCK");
   });
 
+  it("should return a block action when blocked domain is passed with a dot", () => {
+    expect(
+      scanDomain(EMPTY_BLOOM_FILTER, ["google.com"], [], "https://google.com.")
+    ).toBe("BLOCK");
+    expect(
+      scanDomain(
+        EMPTY_BLOOM_FILTER,
+        ["google.com"],
+        [],
+        "https://www.google.com."
+      )
+    ).toBe("BLOCK");
+  });
+
   it("should return a none action when domain is not in the recent list", () => {
     expect(
       scanDomain(EMPTY_BLOOM_FILTER, [], [], "https://www.google.com")


### PR DESCRIPTION
this PR should allow to correctly check domains with "." appended after the domain hostname. previously, these domains have been checked in "scammer.com." form, which is not in the bloom filter.
